### PR TITLE
Implement admin-management panel.

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -9,6 +9,22 @@ const {
 const { updateAirtableEntry } = require("../utils/airtable/utils");
 const Signer = require("../models/Signer");
 
+router.get("/getAdministrators", (req, res) => {
+    Signer.find({"privilege": {$gte: 3}},
+        (err, administrators) => {
+            if (err) {
+                return res
+                    .status(400)
+                    .send({ err: err, message: "Error fetching proposals" });
+            }
+            return res.status(200).json({
+                administrators,
+                success: true,
+            });
+        }
+    );
+});
+
 router.get("/getCompletedProposals", (req, res) => {
   Proposal.find(
     {

--- a/frontend/src/components/ListWithActions.svelte
+++ b/frontend/src/components/ListWithActions.svelte
@@ -3,6 +3,10 @@
 
   export let proposals;
   export let actions;
+
+  async function updateAdminOnClick() {
+
+  }
 </script>
 
 <style>

--- a/frontend/src/components/ListWithAdmins.svelte
+++ b/frontend/src/components/ListWithAdmins.svelte
@@ -1,0 +1,57 @@
+<script>
+  export let levels = [
+      {id: 3, text: '3'},
+      {id: 4, text: '4'},
+      {id: 5, text: '5'},
+  ];
+  export let admins;
+</script>
+
+<style>
+  .listContainer{
+    display: flex;
+    flex-direction: column;
+    background-color: var(--brand-white);
+    max-height: 55vh;
+    overflow-y: auto;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--brand-grey-lighter);
+    box-shadow: 0 6px 15px 0 rgb(0 0 0 / 5%);
+  }
+  .item{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: calc(var(--spacer) / 4)
+  }
+  .list span{
+    text-align: start;
+    font-size: var(--font-size-normal);
+    font-weight: bold;
+    margin-bottom: calc(var(--spacer) / 4)
+  }
+  .text{
+    font-size: var(--font-size-normal);
+    padding: calc(var(--spacer) / 4)
+  }
+</style>
+
+<div class="listContainer">
+    {#if admins.length > 0}
+        {#each admins as admin}
+            <div class="item">
+                <span>{admin.address}</span>
+                <span>Privilege Level {admin.privilege}</span>
+                <select bind:value={admin.privilege}>
+                    {#each levels as level}
+                        <option value={level.id}>
+                            {level.text}
+                        </option>
+                    {/each}
+                </select>
+            </div>
+        {/each}
+    {:else}
+        <div class="text">No Admins</div>
+    {/if}
+</div>

--- a/frontend/src/pages/AdminHomePage.svelte
+++ b/frontend/src/pages/AdminHomePage.svelte
@@ -5,9 +5,13 @@
   import ProjectItemsList from "../components/ProjectItemsList.svelte";
   import Section from "../components/Section.svelte";
   import ListWithActions from "../components/ListWithActions.svelte";
+  import ListWithAdmins from "../components/ListWithAdmins.svelte";
 
   let unacceptedProposals;
   let unacceptedCoreTechProposals;
+  let administrators;
+  let userAdmin;
+  let userPrivLevel;
 
   async function fetchUnacceptedProposals() {
     const res = await fetch(`${SERVER_URI}/app/admin/getCompletedProposals`, {
@@ -37,8 +41,40 @@
     console.log(unacceptedCoreTechProposals)
   }
 
+  async function fetchAdministrators() {
+    const res = await fetch(`${SERVER_URI}/app/admin/getAdministrators`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        'Accept': 'application/json'
+      }
+    });
+    const data = await res.json();
+    administrators = data.administrators;
+
+    console.log(administrators)
+    console.log("User Address: ", userAddress)
+    console.log("User Address: ", $userAddress)
+
+    userAdmin = administrators.filter((admin) => admin.address === $userAddress)
+    if(userAdmin !== undefined)
+      userPrivLevel = userAdmin.privilege;
+
+    console.log("Local user admin object: ", userAdmin)
+    console.log("Local user privilege level: ", userPrivLevel)
+  }
+
+  async function createAdministrator() {
+
+  }
+
+  async function deleteAdministrator() {
+
+  }
+
   fetchUnacceptedProposals();
   fetchCoreTechUnacceptedProposals();
+  fetchAdministrators();
 
   function onReviewProposalClick(proposalId) {
     location.href = `/admin/reviewProposalDeliverables/${proposalId}`;
@@ -96,6 +132,13 @@
             }
         ]}
        />
+    {/if}
+  </Section>
+  <Section class="flex text-left bg-grey-200"
+           title="Manage Admins"
+           description={"Use the following panel to create, update, and delete admins."}>
+    {#if administrators}
+      <ListWithAdmins admins={administrators} />
     {/if}
   </Section>
 </div>


### PR DESCRIPTION
### TBD In a separate ticket
- [...] Retrieves local signer account and identifies if privLevel is greater than 5
- [...] Add functionality so privLevel 5 enables create+delete of admins
- [...] Add functionality besides each drop down so you can quickly update another admin's privLevel
- [...] Add functionality besides each drop down so you can quickly delete the admin

### DoD:
Implementation for admin-management FE.
- [x] Retrieves all signers from backend w/ 3+ privLevel
- [x] Display list of admins, their privLevel, and provides a dropDown menu to select the level

https://github.com/oceanprotocol/oceandao-proposal-portal/issues/70