### PR TITLE
Error handler to catch all unhandled errors

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -26,15 +26,14 @@ app.use(function (req, res, next) {
 });
 
 // error handler
-app.use(function (err, req, res) {
+app.use(function (err, req, res, next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
-  res.locals.error = req.app.get("env") === "development" ? err : {};
   console.error(err.message);
 
   // render the error page
   res.status(err.status || 500);
-  res.send("error");
+  res.json({ error: err.message });
 });
 
 app.listen(process.env.PORT, () =>

--- a/backend/utils/airtable/utils.js
+++ b/backend/utils/airtable/utils.js
@@ -122,7 +122,12 @@ async function updateAirtableEntry(recordId, proposal, grantCompleted = false) {
     update["Minimum USD Requested"] = proposal.minUsdRequested;
 
   if (proposal.oneLiner) update["One Liner"] = proposal.oneLiner;
-  await base("Proposals").update(recordId, update);
+  try {
+    await base("Proposals").update(recordId, update);
+  } catch (err) {
+    console.error(err);
+    throw new Error("An error occurred while updating the Airtable entry");
+  }
   return true;
 }
 
@@ -175,7 +180,14 @@ async function createAirtableEntry({
       "[ ] " + NodeHtmlMarkdown.NodeHtmlMarkdown.translate(grantDeliverables),
   };
 
-  const id = await base("Proposals").create(proposal);
+  let id;
+  try {
+    id = await base("Proposals").create(proposal);
+  } catch (err) {
+    console.error(err);
+    throw new Error("An error occurred while creating the Airtable entry");
+  }
+
   return id.id;
 }
 


### PR DESCRIPTION
Fixes #117.

Changes proposed in this PR:

- Express error handler to catch all unhandled errors
- Airtable error messages - when updating & creating entries

Should we show the error message to the user for each error?