### PR TITLE
Use `delivered.status` to get `canCreateProposals`

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -8,6 +8,7 @@ const {
 } = require("../utils/discourse/utils");
 const { updateAirtableEntry } = require("../utils/airtable/utils");
 const Signer = require("../models/Signer");
+const { cacheSpecificProposal } = require("../utils/redis/cacher");
 
 router.get("/getCompletedProposals", (req, res) => {
   Proposal.find(
@@ -92,6 +93,7 @@ router.post(
             proposalStanding: "Completed",
           });
         }
+        cacheSpecificProposal(data.airtableRecordId);
         return res.send({ success: true });
       }
     );

--- a/backend/routes/project.js
+++ b/backend/routes/project.js
@@ -394,7 +394,7 @@ router.get("/info/:projectId", async (req, res) => {
   const projectId = req.params.projectId;
   Proposal.find(
     { projectId: projectId },
-    "proposalFundingRequested proposalTitle round proposalEarmark airtableRecordId delivered"
+    "proposalFundingRequested proposalTitle round proposalEarmark airtableRecordId"
   )
     .sort({ round: -1 }) // descending
     .exec((err, proposals) => {
@@ -406,10 +406,11 @@ router.get("/info/:projectId", async (req, res) => {
           proposals.map((x) => x.airtableRecordId),
           "."
         );
-        const lastProposal = proposals[0];
-        const canCreateProposals = lastProposal
-          ? lastProposal.delivered.status == 2
-          : true;
+        const canCreateProposals = !airtableInfos.some(
+          (x) =>
+            x["Proposal Standing"] === "Unreported" &&
+            x["Proposal State"] === "Funded"
+        );
 
         res.status(200).send({
           project,

--- a/backend/routes/project.js
+++ b/backend/routes/project.js
@@ -396,7 +396,7 @@ router.get("/info/:projectId", async (req, res) => {
     { projectId: projectId },
     "proposalFundingRequested proposalTitle round proposalEarmark airtableRecordId delivered"
   )
-    .sort({ round: -1 })
+    .sort({ round: -1 }) // descending
     .exec((err, proposals) => {
       Project.findById(projectId, async (err, project) => {
         if (err) {
@@ -406,7 +406,7 @@ router.get("/info/:projectId", async (req, res) => {
           proposals.map((x) => x.airtableRecordId),
           "."
         );
-        const lastProposal = proposals[proposals.length - 1];
+        const lastProposal = proposals[0];
         const canCreateProposals = lastProposal
           ? lastProposal.delivered.status == 2
           : true;

--- a/backend/routes/project.js
+++ b/backend/routes/project.js
@@ -394,7 +394,7 @@ router.get("/info/:projectId", async (req, res) => {
   const projectId = req.params.projectId;
   Proposal.find(
     { projectId: projectId },
-    "proposalFundingRequested proposalTitle round proposalEarmark airtableRecordId"
+    "proposalFundingRequested proposalTitle round proposalEarmark airtableRecordId delivered"
   )
     .sort({ round: -1 })
     .exec((err, proposals) => {
@@ -406,11 +406,10 @@ router.get("/info/:projectId", async (req, res) => {
           proposals.map((x) => x.airtableRecordId),
           "."
         );
-        const canCreateProposals = !airtableInfos.some(
-          (x) =>
-            x["Proposal Standing"] === "Unreported" &&
-            x["Proposal State"] === "Funded"
-        );
+        const lastProposal = proposals[proposals.length - 1];
+        const canCreateProposals = lastProposal
+          ? lastProposal.delivered.status == 2
+          : true;
 
         res.status(200).send({
           project,


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- [Use delivered.status to get canCreateProposals](https://github.com/oceanprotocol/oceandao-proposal-portal/commit/a52384c6a149ff014dcc055f3bde5ada4e161d55)
- 
- 