### PR TITLE
Fix creating a proposal for the next round picks wrong discourse category

### DIFF
--- a/backend/routes/project.js
+++ b/backend/routes/project.js
@@ -17,8 +17,8 @@ const {
   getProjectUsdLimit,
   createAirtableEntry,
   getFormerFundedProposals,
-  getCurrentRound,
   batchUpdateProposals,
+  getCurrentSubmissionRound,
 } = require("../utils/airtable/utils");
 const { hasEnoughOceans } = require("../utils/ethers/balance");
 const { cacheSpecificProposal } = require("../utils/redis/cacher");
@@ -141,15 +141,8 @@ router.post(
       });
     }
 
-    const currentRound = await getCurrentRound();
-    let currentRoundNumber = parseInt(currentRound.fields["Round"]);
-    const currentRoundSubmissionDeadline =
-      currentRound.fields["Proposals Due By"];
-
-    // if submission deadline has passed, return error
-    if (Date.now() > new Date(currentRoundSubmissionDeadline).getTime()) {
-      currentRoundNumber = parseInt(currentRoundNumber) + 1; // submit proposal for next round
-    }
+    const currentRound = await getCurrentSubmissionRound();
+    const currentRoundNumber = parseInt(currentRound.fields["Round"]);
 
     Proposal.findOne(
       {

--- a/backend/utils/airtable/utils.js
+++ b/backend/utils/airtable/utils.js
@@ -126,6 +126,14 @@ async function getCurrentRoundNumber() {
   return roundParameters ? roundParameters.fields["Round"] : -1;
 }
 
+async function getCurrentSubmissionRound() {
+  const nowDateString = new Date().toISOString();
+  const roundParameters = await _getFundingRoundsSelectQuery(
+    `AND({Proposals Due By} > "${nowDateString}", "true")`
+  );
+  return roundParameters ? roundParameters.slice(-1) : null;
+}
+
 /**
  * Returns the current round
  * @return {object} current round
@@ -263,4 +271,5 @@ module.exports = {
   getAllProposalRecords,
   getCurrentRoundProposals,
   batchUpdateProposals,
+  getCurrentSubmissionRound,
 };


### PR DESCRIPTION
Fixes #173 .

Changes proposed in this PR:

- [Add getCurrentSubmissionRound func](https://github.com/oceanprotocol/oceandao-proposal-portal/commit/da971ada1800a8e89b1e42f318a5137a9d75f012)
- [Use getCurrentSubmissionRound when creating proposal](https://github.com/oceanprotocol/oceandao-proposal-portal/commit/1988290481f98529bf28ed1792b1b5248ec298fa)