### PR TITLE
Fix/available earmarks

### DIFF
--- a/backend/routes/utils/proposal-utils.js
+++ b/backend/routes/utils/proposal-utils.js
@@ -10,7 +10,6 @@ function getAvailableEarmarks({ grantsCompleted, projectCategory }) {
     }
   } else {
     availableEarmaks.push("general");
-    availableEarmaks.push("outreach");
   }
 
   if (grantsCompleted === 1 || grantsCompleted === 2) {

--- a/backend/routes/utils/proposal-utils.js
+++ b/backend/routes/utils/proposal-utils.js
@@ -5,7 +5,6 @@ function getAvailableEarmarks({ grantsCompleted, projectCategory }) {
       availableEarmaks.push("newprojectoutreach");
     }
     else {
-      availableEarmaks.push("newprojectoutreach");
       availableEarmaks.push("newproject");
     }
   } else {

--- a/backend/routes/utils/proposal-utils.js
+++ b/backend/routes/utils/proposal-utils.js
@@ -5,14 +5,13 @@ function getAvailableEarmarks({ grantsCompleted, projectCategory }) {
       availableEarmaks.push("newprojectoutreach");
     }
     else {
+      availableEarmaks.push("newprojectoutreach");
       availableEarmaks.push("newproject");
     }
+  } else if (grantsCompleted === 1 || grantsCompleted === 2) {
+    availableEarmaks.push("2nd3rd");
   } else {
     availableEarmaks.push("general");
-  }
-
-  if (grantsCompleted === 1 || grantsCompleted === 2) {
-    availableEarmaks.push("2nd3rd");
   }
 
   availableEarmaks.push("coretech");


### PR DESCRIPTION
New teams can't select their "new earmarks" anymore.

They should instead select a different project category, in order to access 1 of the 2 "new earmarks"